### PR TITLE
what is the preferred method of adding sha3 support?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ erl_crash.dump
 log
 logs
 build
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "crypto",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@noble/hashes": "^1.4.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@noble/hashes": "^1.4.0"
+  }
+}

--- a/src/gleam/crypto.gleam
+++ b/src/gleam/crypto.gleam
@@ -1,9 +1,9 @@
 //// Set of cryptographic functions.
 
 import gleam/bit_array
-import gleam/string
 import gleam/int
 import gleam/result
+import gleam/string
 
 /// Generates a specified number of bytes randomly uniform 0..255, and returns
 /// the result in a binary.
@@ -24,6 +24,10 @@ pub type HashAlgorithm {
   Sha256
   Sha384
   Sha512
+  Sha3224
+  Sha3256
+  Sha3384
+  Sha3512
   /// The MD5 hash algorithm is considered weak and should not be used for
   /// security purposes. It may still be useful for non-security purposes or for
   /// compatibility with existing systems.
@@ -31,7 +35,7 @@ pub type HashAlgorithm {
 }
 
 /// Computes a digest of the input bit string.
-@external(erlang, "crypto", "hash")
+@external(erlang, "gleam_crypto_ffi", "hash")
 @external(javascript, "../gleam_crypto_ffi.mjs", "hash")
 pub fn hash(a: HashAlgorithm, b: BitArray) -> BitArray
 
@@ -93,6 +97,10 @@ fn signing_input(digest_type: HashAlgorithm, message: BitArray) -> String {
     Sha256 -> "HS256"
     Sha384 -> "HS384"
     Sha512 -> "HS512"
+    Sha3224 -> "HS3224"
+    Sha3256 -> "HS3256"
+    Sha3384 -> "HS3384"
+    Sha3512 -> "HS3512"
     Md5 -> "Md5"
   }
   string.concat([
@@ -129,6 +137,14 @@ pub fn verify_signed_message(
     <<72, 83, 51, 56, 52>> -> Ok(Sha384)
     // <<"HS512":utf8>> 
     <<72, 83, 53, 49, 50>> -> Ok(Sha512)
+    // <<"HS3224":utf8>>
+    <<72, 83, 51, 50, 50, 52>> -> Ok(Sha3224)
+    // <<"HS3256":utf8>>
+    <<72, 83, 51, 50, 53, 54>> -> Ok(Sha3256)
+    // <<"HS3384":utf8>>
+    <<72, 83, 51, 51, 56, 52>> -> Ok(Sha3384)
+    // <<"HS3512":utf8>>
+    <<72, 83, 51, 53, 49, 50>> -> Ok(Sha3512)
     _ -> Error(Nil)
   })
   let challenge = hmac(<<text:utf8>>, digest_type, secret)

--- a/src/gleam_crypto_ffi.erl
+++ b/src/gleam_crypto_ffi.erl
@@ -1,5 +1,14 @@
 -module(gleam_crypto_ffi).
--export([hmac/3]).
+-export([hmac/3, hash/2]).
 
-hmac(Data, Algorithm, Key) ->
-    crypto:mac(hmac, Algorithm, Key, Data).
+hash('sha3224', Data) -> crypto:hash('sha3_224', Data);
+hash('sha3256', Data) -> crypto:hash('sha3_256', Data);
+hash('sha3384', Data) -> crypto:hash('sha3_384', Data);
+hash('sha3512', Data) -> crypto:hash('sha3_512', Data);
+hash(Algorithm, Data) -> crypto:hash(Algorithm, Data).
+
+hmac(Data, 'sha3224', Key) -> crypto:mac(hmac, 'sha3_224', Key, Data);
+hmac(Data, 'sha3256', Key) -> crypto:mac(hmac, 'sha3_256', Key, Data);
+hmac(Data, 'sha3384', Key) -> crypto:mac(hmac, 'sha3_384', Key, Data);
+hmac(Data, 'sha3512', Key) -> crypto:mac(hmac, 'sha3_512', Key, Data);
+hmac(Data, Algorithm, Key) -> crypto:mac(hmac, Algorithm, Key, Data).

--- a/src/gleam_crypto_ffi.mjs
+++ b/src/gleam_crypto_ffi.mjs
@@ -1,5 +1,15 @@
 import { BitArray } from "./gleam.mjs";
-import { Sha224, Sha256, Sha384, Sha512, Md5 } from "./gleam/crypto.mjs";
+import {
+  Sha224,
+  Sha256,
+  Sha384,
+  Sha512,
+  Sha3224,
+  Sha3256,
+  Sha3384,
+  Sha3512,
+  Md5,
+} from "./gleam/crypto.mjs";
 import * as crypto from "node:crypto";
 
 function webCrypto() {
@@ -10,18 +20,18 @@ function webCrypto() {
 }
 
 function algorithmName(algorithm) {
-  if (algorithm instanceof Sha224) {
-    return "sha224";
-  } else if (algorithm instanceof Sha256) {
-    return "sha256";
-  } else if (algorithm instanceof Sha384) {
-    return "sha384";
-  } else if (algorithm instanceof Sha512) {
-    return "sha512";
-  } else if (algorithm instanceof Md5) {
-    return "md5";
-  } else {
-    throw new Error("Unsupported algorithm");
+  switch (true) {
+    case algorithm instanceof Sha224: return "sha224";
+    case algorithm instanceof Sha256: return "sha256";
+    case algorithm instanceof Sha256: return "sha256";
+    case algorithm instanceof Sha384: return "sha384";
+    case algorithm instanceof Sha512: return "sha512";
+    case algorithm instanceof Sha3224: return "sha3-224";
+    case algorithm instanceof Sha3256: return "sha3-256";
+    case algorithm instanceof Sha3384: return "sha3-384";
+    case algorithm instanceof Sha3512: return "sha3-512";
+    case algorithm instanceof Md5: return "md5";
+    default: throw new Error("Unsupported algorithm");
   }
 }
 

--- a/test/gleam/crypto_test.gleam
+++ b/test/gleam/crypto_test.gleam
@@ -45,6 +45,41 @@ pub fn hash_sha512_test() {
   >>)
 }
 
+pub fn hash_sha3_224_test() {
+  crypto.hash(crypto.Sha3224, <<"hi":utf8>>)
+  |> should.equal(<<
+    69, 56, 170, 204, 108, 202, 225, 103, 235, 70, 43, 210, 214, 206, 211, 83,
+    126, 223, 111, 141, 136, 175, 112, 155, 231, 177, 48, 192,
+  >>)
+}
+
+pub fn hash_sha3_256_test() {
+  crypto.hash(crypto.Sha3256, <<"hi":utf8>>)
+  |> should.equal(<<
+    179, 156, 20, 200, 218, 59, 35, 129, 31, 100, 21, 183, 224, 179, 53, 38, 215,
+    224, 122, 70, 242, 207, 4, 132, 23, 148, 53, 118, 126, 74, 136, 4,
+  >>)
+}
+
+pub fn hash_sha3_384_test() {
+  crypto.hash(crypto.Sha3384, <<"hi":utf8>>)
+  |> should.equal(<<
+    26, 63, 130, 34, 74, 227, 192, 147, 61, 151, 199, 226, 229, 212, 139, 115,
+    249, 62, 173, 249, 16, 87, 161, 181, 77, 78, 189, 217, 236, 55, 189, 77, 115,
+    200, 251, 155, 150, 81, 93, 171, 252, 111, 160, 163, 55, 145, 243, 212,
+  >>)
+}
+
+pub fn hash_sha3_512_test() {
+  crypto.hash(crypto.Sha3512, <<"hi":utf8>>)
+  |> should.equal(<<
+    21, 64, 19, 203, 129, 64, 199, 83, 240, 172, 53, 141, 166, 17, 15, 226, 55,
+    72, 27, 38, 199, 92, 61, 220, 27, 89, 234, 249, 221, 123, 70, 160, 163, 174,
+    178, 206, 241, 100, 179, 200, 45, 101, 179, 138, 78, 38, 234, 153, 48, 183,
+    178, 203, 60, 1, 218, 75, 163, 49, 201, 94, 98, 204, 185, 195,
+  >>)
+}
+
 pub fn hash_md5_test() {
   crypto.hash(crypto.Md5, <<"hi":utf8>>)
   |> should.equal(<<
@@ -88,6 +123,45 @@ pub fn hmac_sha512_test() {
     160, 60, 66, 220, 202, 26, 48, 237, 14, 53, 239, 74, 128, 194, 103, 182, 14,
     122, 31, 46, 26, 94, 1, 82, 22, 206, 122, 94, 1, 219, 240, 237, 41, 83, 39,
     149, 237, 179, 39, 132, 160, 170, 5, 160, 231, 143, 105,
+  >>)
+}
+
+pub fn hmac_sha3_224_test() {
+  <<"Aladin":utf8>>
+  |> crypto.hmac(crypto.Sha3224, <<"secret":utf8>>)
+  |> should.equal(<<
+    232, 220, 105, 240, 79, 34, 133, 213, 124, 62, 178, 35, 67, 179, 211, 229,
+    98, 219, 225, 97, 239, 143, 246, 153, 203, 183, 117, 139,
+  >>)
+}
+
+pub fn hmac_sha3_256_test() {
+  <<"Aladin":utf8>>
+  |> crypto.hmac(crypto.Sha3256, <<"secret":utf8>>)
+  |> should.equal(<<
+    173, 168, 107, 108, 225, 130, 112, 44, 253, 29, 220, 36, 255, 204, 189, 191,
+    217, 211, 240, 174, 4, 201, 209, 254, 138, 89, 214, 224, 24, 123, 114, 171,
+  >>)
+}
+
+pub fn hmac_sha3_384_test() {
+  <<"Aladin":utf8>>
+  |> crypto.hmac(crypto.Sha3384, <<"secret":utf8>>)
+  |> should.equal(<<
+    188, 250, 41, 176, 237, 143, 249, 135, 114, 39, 133, 97, 194, 116, 201, 135,
+    172, 105, 174, 188, 174, 188, 99, 63, 207, 232, 8, 185, 249, 92, 99, 203, 81,
+    74, 229, 79, 93, 153, 134, 129, 233, 216, 153, 206, 226, 211, 19, 52,
+  >>)
+}
+
+pub fn hmac_sha3_512_test() {
+  <<"Aladin":utf8>>
+  |> crypto.hmac(crypto.Sha3512, <<"secret":utf8>>)
+  |> should.equal(<<
+    183, 220, 43, 80, 10, 76, 189, 8, 173, 58, 215, 174, 241, 115, 117, 140, 130,
+    167, 203, 72, 80, 39, 238, 148, 20, 219, 61, 70, 197, 48, 143, 89, 182, 173,
+    232, 212, 242, 140, 99, 20, 135, 99, 41, 36, 3, 191, 158, 198, 28, 54, 25,
+    24, 123, 179, 13, 120, 191, 195, 205, 148, 4, 84, 26, 115,
   >>)
 }
 
@@ -169,6 +243,50 @@ pub fn sign_message_512_test() {
   )
 }
 
+pub fn sign_message_3224_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3224)
+  |> should.equal("SFMzMjI0.SGVsbG8h.hER6RkviDh6bq8d3cZxxeMFEQmW6bN8kwukx6Q")
+
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret2":utf8>>, crypto.Sha3224)
+  |> should.equal("SFMzMjI0.SGVsbG8h.mS7eAl6w02Q6O8z-2zaAXxy3VdHE-n5ArpwF-Q")
+}
+
+pub fn sign_message_3256_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3256)
+  |> should.equal(
+    "SFMzMjU2.SGVsbG8h.Az5595iJ9pb53uxffgKkug7Y9jE1Zp_8p1nfIYSbORk",
+  )
+
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret2":utf8>>, crypto.Sha3256)
+  |> should.equal(
+    "SFMzMjU2.SGVsbG8h.b1XrlYvzyKjTGl9y7cj9kdGQI1cfIqCu0iltf38ZHno",
+  )
+}
+
+pub fn sign_message_3384_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3384)
+  |> should.equal(
+    "SFMzMzg0.SGVsbG8h.N1kJfavh4lVUrhbFQxAILkHbEYQzd9jz2S0qePpalT7vMFqp5xRLpTIT9FT2DrTj",
+  )
+
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret2":utf8>>, crypto.Sha3384)
+  |> should.equal(
+    "SFMzMzg0.SGVsbG8h.G0WRG9XdDE6Y-kd5MkZP1QzONWTGBSnyj9IL-5TgZdIB_Hmv9mT3lkM39NTqwJph",
+  )
+}
+
+pub fn sign_message_3512_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3512)
+  |> should.equal(
+    "SFMzNTEy.SGVsbG8h.fGuDx_7ML4x8x8e4oGiLbigorLtDg3RA3IPUNCZjFwGLR7Mhz2x3IG6jSKwftvbMuKhnbEtkGOIXe3pNGPebFw",
+  )
+
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret2":utf8>>, crypto.Sha3512)
+  |> should.equal(
+    "SFMzNTEy.SGVsbG8h.Hfq7oz53v2Gl_VkL1p54ngHJexqOTSU7j8ps4q14LnioQNOsWb5EV2QLuFSxK8wvypS0ppZiBKhkbZrBN7xsiA",
+  )
+}
+
 pub fn verify_signed_message_256_ok_test() {
   crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha256)
   |> crypto.verify_signed_message(<<"secret":utf8>>)
@@ -213,6 +331,55 @@ pub fn verify_signed_message_512_ok_test() {
 
 pub fn verify_signed_message_512_ko_test() {
   crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha512)
+  |> crypto.verify_signed_message(<<"other":utf8>>)
+  |> should.equal(Error(Nil))
+}
+
+pub fn verify_signed_message_3224_ok_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3224)
+  |> crypto.verify_signed_message(<<"secret":utf8>>)
+  |> should.equal(Ok(<<"Hello!":utf8>>))
+}
+
+pub fn verify_signed_message_3224_ko_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3224)
+  |> crypto.verify_signed_message(<<"other":utf8>>)
+  |> should.equal(Error(Nil))
+}
+
+pub fn verify_signed_message_3256_ok_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3256)
+  |> crypto.verify_signed_message(<<"secret":utf8>>)
+  |> should.equal(Ok(<<"Hello!":utf8>>))
+}
+
+pub fn verify_signed_message_3256_ko_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3256)
+  |> crypto.verify_signed_message(<<"other":utf8>>)
+  |> should.equal(Error(Nil))
+}
+
+
+pub fn verify_signed_message_3384_ok_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3384)
+  |> crypto.verify_signed_message(<<"secret":utf8>>)
+  |> should.equal(Ok(<<"Hello!":utf8>>))
+}
+
+pub fn verify_signed_message_3384_ko_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3384)
+  |> crypto.verify_signed_message(<<"other":utf8>>)
+  |> should.equal(Error(Nil))
+}
+
+pub fn verify_signed_message_3512_ok_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3512)
+  |> crypto.verify_signed_message(<<"secret":utf8>>)
+  |> should.equal(Ok(<<"Hello!":utf8>>))
+}
+
+pub fn verify_signed_message_3512_ko_test() {
+  crypto.sign_message(<<"Hello!":utf8>>, <<"secret":utf8>>, crypto.Sha3512)
   |> crypto.verify_signed_message(<<"other":utf8>>)
   |> should.equal(Error(Nil))
 }


### PR DESCRIPTION
My [first iteration](https://github.com/gleam-lang/crypto/compare/main...quixoten:gleam-crypto:sha3) added sha3 without relying on a node module. That approach works for erlang and nodejs, but fails for the other js runtimes. This approach uses the [@noble/hashes](https://github.com/paulmillr/noble-hashes) library for pure js implementations of the hashing algorithms (except md5). This works on all js platforms, but I'm not sure this is valid either. I wasn't able to find other examples of gleam libraries that bundle up node module dependencies in the build, and I can understand why it would be preferable to avoid external dependencies (especially in a core library like this).

Let me know if there's a path forward here, but understand if this should just be left out for now, or handled in a separate package.

