### PR TITLE
feat: remove restriction on node

### DIFF
--- a/src/gleam_crypto_ffi.mjs
+++ b/src/gleam_crypto_ffi.mjs
@@ -1,6 +1,6 @@
 import { BitArray } from "./gleam.mjs";
 import { Sha1, Sha224, Sha256, Sha384, Sha512, Md5 } from "./gleam/crypto.mjs";
-import * as crypto from "node:crypto";
+import * as crypto from "crypto";
 
 function webCrypto() {
   if (!globalThis.crypto?.getRandomValues) {


### PR DESCRIPTION
Just removing the restriction on `node:` from the protocol imports so the package can run against multiple JS engines. This is addressing https://github.com/gleam-lang/crypto/issues/13.